### PR TITLE
make environment.yaml work with conda `channel_priority strict`

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,6 +1,6 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
 dependencies:
   - snakemake-minimal >=7.3
   - jinja2


### PR DESCRIPTION
[bioconda installation instructions](https://bioconda.github.io/) were switched to include `conda config --set channel_priority strict` a while ago, in concert with making `conda-forge` the highest priority, before `bioconda`. This ensures this order for the snakemake tutorial environment definition file.